### PR TITLE
typo: removed a trailing ')'; which was blocking 'background-image:ur…

### DIFF
--- a/app/views/products/categories.html.haml
+++ b/app/views/products/categories.html.haml
@@ -4,8 +4,7 @@
   %ul
     - for category in @product_categories
       %li
-        %div.img{:style => category.image ? "background-image:url(#{category.image.path})" : 'background-color:#efefef'}
+        %div.img{:style => category.image ? "background-image:url(#{category.image.path}" : 'background-color:#efefef'}
         .space
           %h4= link_to category.name, products_path(category.permalink)
           %p= category.description
-      


### PR DESCRIPTION
Hi,

Here is a quick edit of the `categories.html.haml` view.

There was a trailing `)` which was blocking the categories images from being rendered.